### PR TITLE
test: add unit tests for core use cases

### DIFF
--- a/internal/usecases/copier/file_copier_test.go
+++ b/internal/usecases/copier/file_copier_test.go
@@ -1,0 +1,147 @@
+package copier
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/makinzm/partial-tree-copy/internal/domain/entities"
+	"github.com/makinzm/partial-tree-copy/internal/domain/repositories"
+)
+
+// Why test FileCopier?
+//
+// FileCopier produces the final clipboard text that the user pastes into
+// code reviews, AI prompts, or documentation. The output format is a contract:
+// it must have the "★★" header, the correct relative path, and the file
+// content. If the format drifts (e.g. missing newline, wrong path), every
+// downstream consumer breaks silently. These tests lock in that contract.
+
+// --- mock repository ---
+
+type mockDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (m mockDirEntry) Name() string { return m.name }
+func (m mockDirEntry) IsDir() bool  { return m.isDir }
+
+type mockFileRepo struct {
+	currentDir    string
+	files         map[string][]byte
+	clipboardText string
+}
+
+func (m *mockFileRepo) GetCurrentDirectory() (string, error) { return m.currentDir, nil }
+func (m *mockFileRepo) ReadDirectory(string) ([]repositories.DirEntry, error) {
+	return nil, nil
+}
+func (m *mockFileRepo) ReadFile(path string) ([]byte, error) {
+	content, ok := m.files[path]
+	if !ok {
+		return nil, fmt.Errorf("file not found: %s", path)
+	}
+	return content, nil
+}
+func (m *mockFileRepo) GetRelativePath(target, base string) (string, error) {
+	// Simple mock: strip base prefix
+	rel := strings.TrimPrefix(target, base+"/")
+	return rel, nil
+}
+func (m *mockFileRepo) WriteToClipboard(content string) error {
+	m.clipboardText = content
+	return nil
+}
+
+// The golden-path test: one file selected, copied to clipboard. Verifies the
+// exact output format including the "★★" header, relative path, content, and
+// trailing newlines. This format is a user-facing contract — AI tools and
+// reviewers parse it, so even a missing newline is a breaking change.
+func TestCopySelectionToClipboard_SingleFile(t *testing.T) {
+	repo := &mockFileRepo{
+		currentDir: "/project",
+		files: map[string][]byte{
+			"/project/main.go": []byte("package main"),
+		},
+	}
+	cp := NewFileCopier(repo)
+
+	node := entities.NewFileNode("main.go", "/project/main.go", false, nil)
+	selection := map[string]*entities.FileNode{
+		node.Path: node,
+	}
+
+	if err := cp.CopySelectionToClipboard(selection); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := "★★ The contents of main.go is below.\npackage main\n\n"
+	if repo.clipboardText != expected {
+		t.Fatalf("clipboard mismatch.\nwant: %q\ngot:  %q", expected, repo.clipboardText)
+	}
+}
+
+// An empty selection must not error and must write empty string to clipboard.
+// Without this, pressing "copy" with nothing selected could panic on nil map
+// iteration or overwrite the user's existing clipboard with garbage.
+func TestCopySelectionToClipboard_EmptySelection(t *testing.T) {
+	repo := &mockFileRepo{currentDir: "/project"}
+	cp := NewFileCopier(repo)
+
+	selection := map[string]*entities.FileNode{}
+	if err := cp.CopySelectionToClipboard(selection); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if repo.clipboardText != "" {
+		t.Fatalf("expected empty clipboard for empty selection, got %q", repo.clipboardText)
+	}
+}
+
+// A file might be deleted between selection and copy (e.g. by another process).
+// The copier must skip it gracefully rather than returning an error or crashing,
+// so the user still gets the rest of their selection.
+func TestCopySelectionToClipboard_SkipsMissingFile(t *testing.T) {
+	repo := &mockFileRepo{
+		currentDir: "/project",
+		files:      map[string][]byte{}, // no files
+	}
+	cp := NewFileCopier(repo)
+
+	node := entities.NewFileNode("gone.go", "/project/gone.go", false, nil)
+	selection := map[string]*entities.FileNode{node.Path: node}
+
+	if err := cp.CopySelectionToClipboard(selection); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Missing file should be silently skipped
+	if repo.clipboardText != "" {
+		t.Fatalf("expected empty clipboard when file is missing, got %q", repo.clipboardText)
+	}
+}
+
+// Verifies that nested files use their relative path (src/lib.go) in the
+// header, not the absolute path (/project/src/lib.go). Absolute paths leak
+// the user's directory structure and break portability when sharing snippets.
+func TestCopySelectionToClipboard_FormatContainsStarHeader(t *testing.T) {
+	repo := &mockFileRepo{
+		currentDir: "/project",
+		files: map[string][]byte{
+			"/project/src/lib.go": []byte("package lib"),
+		},
+	}
+	cp := NewFileCopier(repo)
+
+	node := entities.NewFileNode("lib.go", "/project/src/lib.go", false, nil)
+	selection := map[string]*entities.FileNode{node.Path: node}
+
+	if err := cp.CopySelectionToClipboard(selection); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(repo.clipboardText, "★★ The contents of src/lib.go is below.") {
+		t.Fatalf("clipboard should contain star header with relative path, got %q", repo.clipboardText)
+	}
+}

--- a/internal/usecases/copier/file_copier_test.go
+++ b/internal/usecases/copier/file_copier_test.go
@@ -19,14 +19,6 @@ import (
 
 // --- mock repository ---
 
-type mockDirEntry struct {
-	name  string
-	isDir bool
-}
-
-func (m mockDirEntry) Name() string { return m.name }
-func (m mockDirEntry) IsDir() bool  { return m.isDir }
-
 type mockFileRepo struct {
 	currentDir    string
 	files         map[string][]byte

--- a/internal/usecases/navigator/file_navigator_test.go
+++ b/internal/usecases/navigator/file_navigator_test.go
@@ -1,0 +1,280 @@
+package navigator
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/makinzm/partial-tree-copy/internal/domain/entities"
+	"github.com/makinzm/partial-tree-copy/internal/domain/repositories"
+)
+
+// Why test FileNavigator?
+//
+// FileNavigator is the core tree-traversal engine. It decides which nodes the
+// user sees (GetVisibleNodes), how deep each node is (GetNodeLevel), how to
+// jump between directories, and how breadcrumbs are built. A bug here means
+// the user sees the wrong files, selects the wrong items, or gets lost in the
+// tree. None of this logic is covered by the existing web-server tests.
+
+// --- mock repository ---
+
+type mockDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (m mockDirEntry) Name() string { return m.name }
+func (m mockDirEntry) IsDir() bool  { return m.isDir }
+
+type mockFileRepo struct {
+	currentDir string
+	dirs       map[string][]repositories.DirEntry
+}
+
+func (m *mockFileRepo) GetCurrentDirectory() (string, error) { return m.currentDir, nil }
+func (m *mockFileRepo) ReadDirectory(path string) ([]repositories.DirEntry, error) {
+	entries, ok := m.dirs[path]
+	if !ok {
+		return nil, fmt.Errorf("directory not found: %s", path)
+	}
+	return entries, nil
+}
+func (m *mockFileRepo) ReadFile(string) ([]byte, error)              { return nil, nil }
+func (m *mockFileRepo) GetRelativePath(string, string) (string, error) { return "", nil }
+func (m *mockFileRepo) WriteToClipboard(string) error                  { return nil }
+
+// --- helpers ---
+
+// buildTestTree creates:
+//
+//	root/
+//	  dirA/
+//	    file1.go
+//	    file2.go
+//	  dirB/
+//	  file3.go
+func buildTestTree() (*entities.FileNode, *FileNavigator) {
+	repo := &mockFileRepo{
+		currentDir: "/root",
+		dirs: map[string][]repositories.DirEntry{
+			"/root": {
+				mockDirEntry{"dirA", true},
+				mockDirEntry{"dirB", true},
+				mockDirEntry{"file3.go", false},
+			},
+			"/root/dirA": {
+				mockDirEntry{"file1.go", false},
+				mockDirEntry{"file2.go", false},
+			},
+			"/root/dirB": {},
+		},
+	}
+
+	nav := NewFileNavigator(repo)
+	root, _ := nav.BuildRootNode()
+	return root, nav
+}
+
+// --- tests ---
+
+// Verifies that BuildRootNode reads the filesystem and creates the correct
+// direct children. If this breaks, the entire tree is empty or malformed on
+// startup and nothing else works.
+func TestBuildRootNode_CreatesCorrectChildren(t *testing.T) {
+	root, _ := buildTestTree()
+
+	if len(root.Children) != 3 {
+		t.Fatalf("expected 3 children, got %d", len(root.Children))
+	}
+
+	// dirA should have 2 children (built lazily, but BuildTree is called recursively from BuildRootNode only for root)
+	dirA := root.Children[0]
+	if dirA.Name != "dirA" || !dirA.IsDir {
+		t.Fatalf("expected dirA directory, got %s (isDir=%v)", dirA.Name, dirA.IsDir)
+	}
+}
+
+// A collapsed root must hide all descendants. Without this guarantee the TUI
+// would render a full tree even when the user hasn't expanded anything yet.
+func TestGetVisibleNodes_CollapsedRoot(t *testing.T) {
+	root, nav := buildTestTree()
+	// Root is not expanded by default
+	root.Expanded = false
+
+	visible := nav.GetVisibleNodes(root)
+	if len(visible) != 1 {
+		t.Fatalf("collapsed root should show 1 node, got %d", len(visible))
+	}
+}
+
+// Expanding root should reveal only its direct children, not grandchildren.
+// A bug here (e.g. recursive expansion) would flood the screen with every file.
+func TestGetVisibleNodes_ExpandedRoot(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+
+	visible := nav.GetVisibleNodes(root)
+	// root + dirA + dirB + file3.go = 4 (dirA/dirB not expanded)
+	if len(visible) != 4 {
+		t.Fatalf("expected 4 visible nodes, got %d", len(visible))
+	}
+}
+
+// Expanding a subdirectory should add its children to the visible list while
+// keeping everything else intact. Tests the recursive traversal path that
+// differs from the single-level expansion above.
+func TestGetVisibleNodes_NestedExpand(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+
+	dirA := root.Children[0]
+	nav.ToggleExpand(dirA) // expand dirA
+
+	visible := nav.GetVisibleNodes(root)
+	// root + dirA + file1 + file2 + dirB + file3 = 6
+	if len(visible) != 6 {
+		t.Fatalf("expected 6 visible nodes, got %d", len(visible))
+	}
+}
+
+// Children are loaded lazily on first expand (not at tree construction time).
+// This is critical for large repos — without lazy loading, BuildRootNode would
+// recursively read the entire filesystem, making startup unusably slow.
+func TestToggleExpand_LoadsChildrenLazily(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+
+	dirA := root.Children[0]
+	// Before toggle, dirA has no children (not yet built for subdirectories)
+	// Actually BuildTree is called once for root, so dirA's children are not populated.
+	// Wait — BuildRootNode calls BuildTree(rootNode) which only builds direct children of root.
+	// dirA children are NOT populated yet.
+	if len(dirA.Children) != 0 {
+		t.Fatalf("dirA should have 0 children before expand, got %d", len(dirA.Children))
+	}
+
+	nav.ToggleExpand(dirA)
+
+	if !dirA.Expanded {
+		t.Fatal("dirA should be expanded after toggle")
+	}
+	if len(dirA.Children) != 2 {
+		t.Fatalf("dirA should have 2 children after expand, got %d", len(dirA.Children))
+	}
+}
+
+// ToggleExpand on a file must be a no-op. If files could be "expanded", the
+// TUI would attempt to read a file as a directory, causing errors or panics.
+func TestToggleExpand_FileNodeIsIgnored(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+
+	fileNode := root.Children[2] // file3.go
+	nav.ToggleExpand(fileNode)
+
+	if fileNode.Expanded {
+		t.Fatal("file node should not become expanded")
+	}
+}
+
+// GetNodeLevel drives indentation in the tree view. Wrong levels make the
+// hierarchy visually misleading — child files would appear at the same indent
+// as their parent directory.
+func TestGetNodeLevel(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+	nav.ToggleExpand(root.Children[0]) // expand dirA
+
+	dirA := root.Children[0]
+	file1 := dirA.Children[0]
+
+	if nav.GetNodeLevel(root) != 0 {
+		t.Fatalf("root level should be 0, got %d", nav.GetNodeLevel(root))
+	}
+	if nav.GetNodeLevel(dirA) != 1 {
+		t.Fatalf("dirA level should be 1, got %d", nav.GetNodeLevel(dirA))
+	}
+	if nav.GetNodeLevel(file1) != 2 {
+		t.Fatalf("file1 level should be 2, got %d", nav.GetNodeLevel(file1))
+	}
+}
+
+// Breadcrumbs show the user where they are in the tree (root > dirA > file1).
+// Incorrect ordering or missing segments would disorient the user when deep
+// in a nested directory structure.
+func TestGetBreadcrumbs(t *testing.T) {
+	root, nav := buildTestTree()
+	nav.ToggleExpand(root.Children[0])
+
+	file1 := root.Children[0].Children[0]
+	crumbs := nav.GetBreadcrumbs(file1)
+
+	if len(crumbs) != 3 {
+		t.Fatalf("expected 3 breadcrumbs (root > dirA > file1), got %d", len(crumbs))
+	}
+	if crumbs[0] != root || crumbs[1] != root.Children[0] || crumbs[2] != file1 {
+		t.Fatal("breadcrumb order is wrong")
+	}
+}
+
+// The J key jumps to the next directory. This must skip over files and stop
+// at the end rather than wrapping or crashing. A bug means the user presses J
+// and lands on a file or gets stuck in an infinite loop.
+func TestMoveToNextDirectory(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+
+	visible := nav.GetVisibleNodes(root)
+	// visible: root, dirA, dirB, file3.go
+
+	next := nav.MoveToNextDirectory(visible, root)
+	if next.Name != "dirA" {
+		t.Fatalf("next dir from root should be dirA, got %s", next.Name)
+	}
+
+	next = nav.MoveToNextDirectory(visible, root.Children[0]) // from dirA
+	if next.Name != "dirB" {
+		t.Fatalf("next dir from dirA should be dirB, got %s", next.Name)
+	}
+
+	// No directory after dirB — should stay
+	next = nav.MoveToNextDirectory(visible, root.Children[1])
+	if next.Name != "dirB" {
+		t.Fatalf("should stay at dirB when no next dir, got %s", next.Name)
+	}
+}
+
+// The K key jumps to the previous directory. Same risks as MoveToNext — must
+// skip files and stay put at the top boundary instead of going out of bounds.
+func TestMoveToPreviousDirectory(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+
+	visible := nav.GetVisibleNodes(root)
+
+	prev := nav.MoveToPreviousDirectory(visible, root.Children[1]) // from dirB
+	if prev.Name != "dirA" {
+		t.Fatalf("prev dir from dirB should be dirA, got %s", prev.Name)
+	}
+
+	prev = nav.MoveToPreviousDirectory(visible, root) // from root — no previous
+	if prev != root {
+		t.Fatal("should stay at root when no previous dir")
+	}
+}
+
+// Edge case: the current node isn't in the visible list (e.g. it was collapsed
+// out of view). The function must return the node as-is rather than panicking
+// on a -1 index.
+func TestMoveToNextDirectory_NodeNotInList(t *testing.T) {
+	root, nav := buildTestTree()
+	root.Expanded = true
+
+	visible := nav.GetVisibleNodes(root)
+	orphan := entities.NewFileNode("orphan", "/orphan", true, nil)
+
+	result := nav.MoveToNextDirectory(visible, orphan)
+	if result != orphan {
+		t.Fatal("should return the same node when not found in visible list")
+	}
+}

--- a/internal/usecases/selector/file_selector_test.go
+++ b/internal/usecases/selector/file_selector_test.go
@@ -1,0 +1,129 @@
+package selector
+
+import (
+	"testing"
+
+	"github.com/makinzm/partial-tree-copy/internal/domain/entities"
+)
+
+// Why test FileSelector?
+//
+// FileSelector manages which files the user has picked. It is the single
+// source of truth for selection state — if ToggleSelect has a bug (e.g.
+// double-toggle doesn't deselect, or directories slip through), the user
+// copies the wrong set of files. The sorting logic also matters: clipboard
+// output order depends on it, so a broken sort means unpredictable output.
+
+// The most basic contract: pressing Space on a file marks it as selected and
+// adds it to the internal map. If this fails, no file can ever be copied.
+func TestToggleSelect_SelectsFile(t *testing.T) {
+	sel := NewFileSelector()
+	node := entities.NewFileNode("main.go", "/src/main.go", false, nil)
+
+	sel.ToggleSelect(node)
+
+	if !node.Selected {
+		t.Fatal("node should be selected after toggle")
+	}
+	if _, ok := sel.GetSelection()["/src/main.go"]; !ok {
+		t.Fatal("node should be in selection map")
+	}
+}
+
+// Double-toggle must deselect. Without this, users cannot undo an accidental
+// selection — they'd have to restart the tool to remove a file from the list.
+func TestToggleSelect_DeselectsFile(t *testing.T) {
+	sel := NewFileSelector()
+	node := entities.NewFileNode("main.go", "/src/main.go", false, nil)
+
+	sel.ToggleSelect(node) // select
+	sel.ToggleSelect(node) // deselect
+
+	if node.Selected {
+		t.Fatal("node should be deselected after second toggle")
+	}
+	if _, ok := sel.GetSelection()["/src/main.go"]; ok {
+		t.Fatal("node should not be in selection map after deselect")
+	}
+}
+
+// Directories must not be selectable — they can't be "copied" as file content.
+// If a directory slips into the selection map, CopySelectionToClipboard would
+// try to read a directory as a file and produce garbage or an error.
+func TestToggleSelect_IgnoresDirectory(t *testing.T) {
+	sel := NewFileSelector()
+	dir := entities.NewFileNode("src", "/src", true, nil)
+
+	sel.ToggleSelect(dir)
+
+	if dir.Selected {
+		t.Fatal("directory should not become selected")
+	}
+	if len(sel.GetSelection()) != 0 {
+		t.Fatal("selection map should be empty after toggling a directory")
+	}
+}
+
+// GetSelectedNodes must return files sorted by path so clipboard output is
+// deterministic. Without sorting, the same selection could produce different
+// clipboard text on each run (map iteration order is random in Go), making
+// the tool's output unreliable for diffs or documentation.
+func TestGetSelectedNodes_SortedByPath(t *testing.T) {
+	sel := NewFileSelector()
+	nodeC := entities.NewFileNode("c.go", "/src/c.go", false, nil)
+	nodeA := entities.NewFileNode("a.go", "/src/a.go", false, nil)
+	nodeB := entities.NewFileNode("b.go", "/src/b.go", false, nil)
+
+	sel.ToggleSelect(nodeC)
+	sel.ToggleSelect(nodeA)
+	sel.ToggleSelect(nodeB)
+
+	nodes := sel.GetSelectedNodes()
+	if len(nodes) != 3 {
+		t.Fatalf("expected 3 selected nodes, got %d", len(nodes))
+	}
+
+	for i := 0; i < len(nodes)-1; i++ {
+		if nodes[i].Path > nodes[i+1].Path {
+			t.Fatalf("nodes not sorted: %s > %s", nodes[i].Path, nodes[i+1].Path)
+		}
+	}
+}
+
+// GetSelectedNodesInTreeOrder must respect the visible-nodes ordering, not
+// alphabetical. The TUI sidebar shows selections in tree order — if this
+// function sorts differently, the sidebar display won't match what the user
+// sees in the main tree panel.
+func TestGetSelectedNodesInTreeOrder(t *testing.T) {
+	sel := NewFileSelector()
+
+	// Simulate a visible-nodes list in tree order
+	nodeA := entities.NewFileNode("a.go", "/a.go", false, nil)
+	nodeB := entities.NewFileNode("b.go", "/b.go", false, nil)
+	nodeC := entities.NewFileNode("c.go", "/c.go", false, nil)
+	dir := entities.NewFileNode("dir", "/dir", true, nil)
+
+	visible := []*entities.FileNode{dir, nodeC, nodeA, nodeB}
+
+	// Select only A and C
+	sel.ToggleSelect(nodeA)
+	sel.ToggleSelect(nodeC)
+
+	result := sel.GetSelectedNodesInTreeOrder(visible)
+	if len(result) != 2 {
+		t.Fatalf("expected 2, got %d", len(result))
+	}
+	// Tree order: C comes before A in the visible list
+	if result[0] != nodeC || result[1] != nodeA {
+		t.Fatal("nodes should follow tree (visible) order, not alphabetical")
+	}
+}
+
+// A fresh selector must have zero selections. This catches initialization bugs
+// where the map might be nil (causing panics) or pre-populated.
+func TestGetSelection_EmptyByDefault(t *testing.T) {
+	sel := NewFileSelector()
+	if len(sel.GetSelection()) != 0 {
+		t.Fatal("new selector should have empty selection")
+	}
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-commit:
+  commands:
+    golangci-lint:
+      run: golangci-lint run ./...


### PR DESCRIPTION
## Summary
- Add 21 unit tests across 3 core business-logic packages that previously had zero coverage
- **navigator** (11 tests): tree building, visibility filtering, lazy child loading, node levels, breadcrumbs, directory jumping, edge cases
- **selector** (6 tests): select/deselect toggle, directory rejection, sorted output, tree-order output, empty-state safety
- **copier** (4 tests): clipboard format contract (`★★` header + relative path), empty selection, missing-file resilience
- Every test function has an inline comment explaining why that specific case is needed

## Test plan
- [x] `go test ./internal/usecases/... -v -race` — all 21 tests pass
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)